### PR TITLE
[fix] Use PropTypes from prop-types lib

### DIFF
--- a/components/CellWrapper.js
+++ b/components/CellWrapper.js
@@ -1,9 +1,7 @@
 'use strict';
 
-import React, {
-  Component,
-  PropTypes
-} from 'react';
+import React, {  Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactNative, {
   View
 } from 'react-native';

--- a/components/SectionHeader.js
+++ b/components/SectionHeader.js
@@ -1,9 +1,7 @@
 'use strict';
 
-import React, {
-  Component,
-  PropTypes
-} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactNative, {
   StyleSheet,
   View,

--- a/components/SectionList.js
+++ b/components/SectionList.js
@@ -1,9 +1,7 @@
 'use strict';
 
-import React, {
-  Component,
-  PropTypes,
-} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactNative, {
   StyleSheet,
   View,
@@ -90,7 +88,7 @@ export default class SectionList extends Component {
     this.fixSectionItemMeasure();
   }
 
-  // fix bug when change data 
+  // fix bug when change data
   componentDidUpdate() {
     this.fixSectionItemMeasure();
   }

--- a/components/SelectableSectionsListView.js
+++ b/components/SelectableSectionsListView.js
@@ -1,10 +1,8 @@
 'use strict';
 /* jshint esnext: true */
 
-import React, {
-  Component,
-  PropTypes,
-} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactNative, {
   ListView,
   StyleSheet,

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "android"
   ],
   "dependencies": {
-    "merge": "^1.2.0"
+    "merge": "^1.2.0",
+    "prop-types": "^15.6.0"
   }
 }


### PR DESCRIPTION
In newer React version PropTypes were moved from react package to a separate package.